### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# canonical-url-plugin
+Improve your website's SEO with the Canonical URL Feature plugin
+
+Upload the canonical-url-plugin directory to the wp-content/plugins folder of your WordPress installation.
+
+Activate the plugin through the WordPress admin dashboard.
+
+After activating the plugin, you should see a new meta box labeled "Canonical URL" when editing posts or pages. You can enter the desired canonical URL for each post or page. The plugin will then automatically add the canonical URL tag to the header of the single post or page if a canonical URL is specified.
+
+Remember to adjust the styling and further customize the plugin as needed for your website's design and functionality.


### PR DESCRIPTION
Upload the canonical-url-plugin directory to the wp-content/plugins folder of your WordPress installation.

Activate the plugin through the WordPress admin dashboard.

After activating the plugin, you should see a new meta box labeled "Canonical URL" when editing posts or pages. You can enter the desired canonical URL for each post or page. The plugin will then automatically add the canonical URL tag to the header of the single post or page if a canonical URL is specified.

Remember to adjust the styling and further customize the plugin as needed for your website's design and functionality.